### PR TITLE
Ithaca2 new sample split contract to be indexed

### DIFF
--- a/src/hicdex/dipdup.yml
+++ b/src/hicdex/dipdup.yml
@@ -39,6 +39,9 @@ contracts:
   SPLIT_contract_sample_d:
     address: KT1XNKmW2786FRK9rGr544JYcmLvcvwn3qEV
     typename: split_contract_a
+  SPLIT_contract_sample_e:
+    address: KT1NcoBQJ5PbGNWCcchhKeYdopvmvugZdeCg
+    typename: split_contract_b
   SPLIT_sign:
     address: KT1BcLnWRziLDNJNRn3phAANKrEBiXhytsMY
     typename: split_sign
@@ -216,3 +219,15 @@ indexes:
         pattern:
           - type: origination
             similar_to: SPLIT_contract_sample_d
+
+  split_contract_b:
+    kind: operation
+    datasource: tzkt_mainnet
+    types:
+      - transaction
+      - origination
+    handlers:
+      - callback: on_split_contract_origination_a
+        pattern:
+          - type: origination
+            similar_to: SPLIT_contract_sample_e


### PR DESCRIPTION
Hi,
After ithaca2 upgrade, it wasn't possible to create new collab contracts (because they used deprecated `SUB` Michelson instruction for tez subtraction). This is why I upgraded collab contracts factory and now it is required to add this new type of contracts to index them at their origination. There is example of this new contract: `KT1NcoBQJ5PbGNWCcchhKeYdopvmvugZdeCg`.

The collab contract storage was changed so I decided to add it with type `split_contract_b` but all storage structure that used to index contract kept the same as with `split_contract_a`. So it might be possible to use it with the same model as `split_contract_a` if dipdup allows not to describe all storage fields.

I wasn't able to test this and I have very least experience with dipdup so it probably wouldn't work as I expected, so I just hope it will not and provided information is enough to make this fix.